### PR TITLE
Client communication MUST be single threaded

### DIFF
--- a/lib/concord.rb
+++ b/lib/concord.rb
@@ -113,7 +113,12 @@ module Concord
       transport = ::Thrift::ServerSocket.new(listen_host, Integer(listen_port))
       transport_factory = ::Thrift::FramedTransportFactory.new
       protocol_factory = ::Thrift::BinaryProtocolAcceleratedFactory.new
-      server = ::Thrift::ThreadedServer.new(processor,
+      # The reason the client computations MUST use a simple blocking server
+      # is that we have process_timer and process_record both which exec as
+      # a callback in the work thread pool which means that you might get
+      # 2 callbacks whichs makes the code multi threaded - we guarantee single
+      # thread for each callback
+      server = ::Thrift::SimpleServer.new(processor,
                                             transport,
                                             transport_factory,
                                             protocol_factory)

--- a/lib/concord.rb
+++ b/lib/concord.rb
@@ -119,9 +119,9 @@ module Concord
       # 2 callbacks whichs makes the code multi threaded - we guarantee single
       # thread for each callback
       server = ::Thrift::SimpleServer.new(processor,
-                                            transport,
-                                            transport_factory,
-                                            protocol_factory)
+                                          transport,
+                                          transport_factory,
+                                          protocol_factory)
       # Register with localhost proxy. Note that this method is `oneway'
       # which means after final TCP 'ack' it finishes.
       handler.register_with_scheduler


### PR DESCRIPTION
- We need to guarantee this at the service level. This ensures
  forward compat with any engine level change as the callback and the
  loop is handled in the same single thread
